### PR TITLE
Support for `binding.irb`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # binding-pry-js
 
-Use `binding.pry` in your JavaScript. Literally just a wrapper for  `debugger`. For those who've been writing a lot of Ruby and can't seem to shake the habit.
+Use `binding.pry` in your JavaScript. Literally just a wrapper for `debugger`. For those who've been writing a lot of Ruby and can't seem to shake the habit.
 
 ## Installation
 
@@ -11,7 +11,7 @@ Use `binding.pry` in your JavaScript. Literally just a wrapper for  `debugger`. 
 Import the script in your code (or load via CDN) and call `binding.pry`. A `debugger` statement will be triggered and you, a Ruby dev, won't feel as stupid as you otherwise would.
 
 ```js
-import binding-pry-js;
+import 'binding-pry-js';
 
 binding.pry
 ```

--- a/index.js
+++ b/index.js
@@ -1,5 +1,9 @@
 globalThis.binding = {
   get pry() {
     debugger;
+  },
+
+  get irb() {
+    debugger;
   }
 }


### PR DESCRIPTION
A few days ago I started writing `binding.pry` in some typescript code and caught myself - but then I thought "I'll just make a module that includes `binding.pry` and `binding.irb` as getters that just invoke `debugger`". It's something my team catches themselves on from time to time, depending on how much ruby they've written lately.

_Then_ I thought "I guess I could publish this for other rubyists!". So I googled it, and _of course_ I found this library 🤣 . Great idea 🧠 ↔️ 🧠 

I humbly submit adding `binding.irb` to this package, since it's the one other ruby debugging context I use.

I also made a small README update - not sure if that import syntax was intentional? Is that valid import syntax in some contexts?